### PR TITLE
Collapse duplicate suffixes  (fixes #2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ script:
   # Require clippy to pass without warnings. This also fails for regular Rust
   # warnings.
   - cargo clippy -- -D warnings
-  # Run our security, license and duplicate dependency version detector.
-  - cargo deny check
 before_deploy:
   #- cargo doc
   - ./build-release geocode-csv "${TRAVIS_TAG}-${TRAVIS_OS_NAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM ekidd/rust-musl-builder:stable-openssl11
 ADD . ./
 RUN sudo chown -R rust:rust .
 
-CMD cargo build --release
+CMD cargo deny check && cargo build --release

--- a/src/async_util.rs
+++ b/src/async_util.rs
@@ -22,7 +22,7 @@ where
     let thr = thread::Builder::new().name(thread_name);
     let handle = thr
         .spawn(move || {
-            if let Err(_) = block_on(sender.send(f())) {
+            if block_on(sender.send(f())).is_err() {
                 panic!("should always be able to send results from background thread");
             }
         })

--- a/src/geocoder.rs
+++ b/src/geocoder.rs
@@ -234,7 +234,7 @@ fn read_csv_from_stdin(
     let chunk_size = max(1, GEOCODE_SIZE / spec.prefix_count());
 
     // Build our output headers.
-    let mut out_headers = in_headers.clone();
+    let mut out_headers = in_headers;
     for prefix in spec.prefixes() {
         structure.add_header_columns(prefix, &mut out_headers)?;
     }
@@ -275,11 +275,7 @@ fn read_csv_from_stdin(
     // rows that haven't been sent yet.
     if !sent_chunk || !rows.is_empty() {
         trace!("sending final {} input rows", rows.len());
-        block_on(tx.send(Message::Chunk(Chunk {
-            shared: shared.clone(),
-            rows,
-        })))
-        .map_err(|_| {
+        block_on(tx.send(Message::Chunk(Chunk { shared, rows }))).map_err(|_| {
             format_err!("could not send rows to geocoder (perhaps it failed)")
         })?;
     }


### PR DESCRIPTION
This is a strange pattern that appears in a lot of databases: Sometimes
two address fields will contain redundant data, and sometimes they
won't. I don't really like this code, because it feels hackish, but it
seems to do what people want.

I'm curious about whether we should do something similar with prefixes.