### PR TITLE
allow --match enhanced

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,8 @@ use crate::structure::Structure;
 #[structopt(about = "geocode CSV files passed on standard input")]
 struct Opt {
     /// `strict` for valid postal addresses only, `range` for unknown addresses
-    /// within a street's known range, and `invalid` to always generate some
-    /// match.
+    /// within a street's known range, `invalid` to always generate some
+    /// match, and `enhanced` if you've paid for it.
     #[structopt(long = "match", default_value = "strict")]
     match_strategy: MatchStrategy,
 

--- a/src/smartystreets.rs
+++ b/src/smartystreets.rs
@@ -51,6 +51,8 @@ pub enum MatchStrategy {
     Range,
     /// Return a candidate for every address.
     Invalid,
+    /// Use "enhanced" matching (which you pay extra for)
+    Enhanced,
 }
 
 impl Default for MatchStrategy {
@@ -69,6 +71,7 @@ impl FromStr for MatchStrategy {
             "strict" => Ok(MatchStrategy::Strict),
             "range" => Ok(MatchStrategy::Range),
             "invalid" => Ok(MatchStrategy::Invalid),
+            "enhanced" => Ok(MatchStrategy::Enhanced),
             _ => Err(format_err!("unknown match strategy {:?}", s)),
         }
     }


### PR DESCRIPTION
In order to use Smarty's new [enhanced matching](https://www.smartystreets.com/products/us-address-verification), you have to pass

```
--match enhanced
```