### PR TITLE
metrics: Report errors by component & cause

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,3 +7,15 @@ use anyhow::Error;
 pub(crate) fn display_causes_and_backtrace(err: &Error) {
     eprintln!("{:?}", err);
 }
+
+/// Given a [`hyper::Error`], return a human-readable description.
+///
+/// This description _should_ be "low-arity", i.e., limited to only a handful of
+/// values. We use it when reporting error metrics.
+pub(crate) fn hyper_error_description_for_metrics(err: &hyper::Error) -> String {
+    // HACK: We know that the current version of `hyper` puts a low-arity
+    // description before ":", but follows it up with variable text.
+    let display_err = err.to_string();
+    let cut_at = display_err.find(':').unwrap_or_else(|| display_err.len());
+    display_err[..cut_at].to_owned()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use geocoders::normalizer::Normalizer;
 use geocoders::smarty::Smarty;
 use geocoders::{shared_http_client, Geocoder};
 use key_value_stores::KeyValueStore;
+use metrics::describe_counter;
 use opinionated_metrics::Mode;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -157,6 +158,13 @@ async fn main() -> Result<()> {
         metrics_builder = metrics_builder.add_global_label(&label.key, &label.value);
     }
     let metrics_handle = metrics_builder.install()?;
+
+    // Describe our global metrics. Other metrics are described in the modules
+    // that use them.
+    describe_counter!(
+        "geocodecsv.selected_errors.count",
+        "Particularly interesting errors, by component and cause"
+    );
 
     // Choose our main geocoding client.
     let mut geocoder: Box<dyn Geocoder> = match opt.geocoder {


### PR DESCRIPTION
We don't do this for _every_ error, because that would take a lot of
code. Instead, we focus on key external systems.

There's a small amount of hackery required to turn errors into low-arity
strings. But this is on the metrics path only, so it should be mostly
OK.
