### PR TITLE
handle the case where an address part gets labeled as a suburb

### DIFF
--- a/src/geocoders/normalizer.rs
+++ b/src/geocoders/normalizer.rs
@@ -135,6 +135,24 @@ fn normalized_to_address(
     // "Brooklyn", with "city" either empty, or containing something
     // like "New York City".
     let mut city = String::with_capacity(32);
+    // In a number of cases, the "important" part of a city name will be parsed out as a suburb.
+    // Here's an example taken from our data:
+    // > 104 16th st belleair bch fl
+    //
+    // Result:
+    //
+    // {
+    //   "house_number": "104",
+    //   "road": "16th st",
+    //   "suburb": "belleair",
+    //   "city": "bch",
+    //   "state": "fl"
+    // }
+    // We need to recapture the "belleair" part of the city, because without it, we only have
+    // "bch", which we have seen to lead to very bad geocodes. It's safe to do this, because
+    // libpostal is never going to just "make up" or add parts to our address which weren't there, so
+    // if there is data in the "suburb" field, we can assume it's part of the city.
+    append_component(component_indices, &mut city, normalized, "suburb");
     append_component(component_indices, &mut city, normalized, "city_district");
     append_component(component_indices, &mut city, normalized, "city");
 

--- a/tests/libpostal.rs
+++ b/tests/libpostal.rs
@@ -6,6 +6,7 @@ use cli_test_dir::*;
 const SIMPLE_CSV: &str = "address_1,address_2,city,state,zip_code
 20 W 34th St,,New York,NY,10118
 1224 S 760 W,,Provo,UT,
+104 16th st,,Belleair Bch,FL,
 ";
 
 #[test]
@@ -35,4 +36,5 @@ fn libpostal() {
         .expect_success();
     assert!(output.stdout_str().contains("gc_city"));
     assert!(output.stdout_str().contains("new york"));
+    assert!(output.stdout_str().contains("belleair"));
 }


### PR DESCRIPTION
See my comment for more details, but we're getting bad results from the geocoder because we're not fully capturing all of the parts of the input address from the normalizer layer (libpostal).