### PR TITLE
Server mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -163,15 +163,16 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
 dependencies = [
  "async-trait",
  "axum-core",
  "bitflags",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -183,10 +184,14 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -204,6 +209,7 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -385,7 +391,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -515,7 +521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -542,7 +548,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -559,7 +565,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -583,7 +589,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -594,7 +600,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -771,7 +777,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -814,9 +820,9 @@ dependencies = [
  "base64 0.21.0",
  "dirs-next",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "ring",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -845,6 +851,7 @@ version = "1.3.7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "bb8",
  "bb8-redis",
  "bigtable_rs",
@@ -854,7 +861,7 @@ dependencies = [
  "csv",
  "futures",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.23.2",
  "jemallocator",
  "leaky-bucket",
  "libpostal-rust",
@@ -862,6 +869,7 @@ dependencies = [
  "metrics-util",
  "opinionated_metrics",
  "redis",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -893,7 +901,7 @@ checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -928,6 +936,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -1024,10 +1057,24 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.20.8",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls 0.21.5",
+ "tokio",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1612,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1738,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -1876,9 +1923,9 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -1889,7 +1936,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.24.1",
  "ipnet",
  "js-sys",
  "log",
@@ -1897,13 +1944,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.5",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1961,6 +2008,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2038,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2049,22 +2118,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.179"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2076,6 +2145,16 @@ dependencies = [
  "indexmap",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2116,7 +2195,18 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2214,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2278,7 +2368,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2369,7 +2459,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2378,9 +2468,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.5",
+ "tokio",
 ]
 
 [[package]]
@@ -2432,7 +2532,7 @@ dependencies = [
  "prost-derive",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -2508,7 +2608,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2593,7 +2693,7 @@ checksum = "2c3e1c30cedd24fc597f7d37a721efdbdc2b1acae012c1ef1218f4c7c2c0f3e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2707,7 +2807,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -2741,7 +2841,7 @@ checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ documentation = "https://github.com/faradayio/geocode-csv"
 
 [dev-dependencies]
 cli_test_dir = "0.1.7"
+reqwest = { version = "0.11.18", default-features = false, features = ["blocking"] }
 
 [dependencies]
 anyhow = { version = "1.0.40", features = ["backtrace"] }
 async-trait = "0.1.52"
+axum = { version = "0.6.19", default-features = false, features = ["http1", "tokio", "tower-log", "tracing", "headers", "json"] }
 bb8 = "0.8.0"
 bb8-redis = "0.12.0"
 bigtable_rs = "=0.2.2"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ You can geocode multiple addresses per row as follows:
 
 This will insert two sets of columns, one beginning with `geocoded_shipping_` and the other with `geocoded_billing_`.
 
+## Build
+
+You'll need to run
+
+```bash
+git submodule update --init
+```
+
 ## A note about Macs
 
 We provide pre-built Mac binaries for Intel- and M1-based Macs. These binaries use "ad-hoc" signatures, so you may need to [set appropriate security settings](https://support.apple.com/en-us/HT202491) or run:

--- a/crates/libpostal-rust/src/init.rs
+++ b/crates/libpostal-rust/src/init.rs
@@ -24,7 +24,7 @@ fn path_as_c_string(path: &Path) -> Result<CString> {
     Ok(c_str.to_owned())
 }
 
-///! Support for initializing `libpostal`.
+/// Support for initializing `libpostal`.
 pub(crate) unsafe fn initialize_libpostal(
     state: &mut InitializationState,
 ) -> Result<()> {
@@ -40,7 +40,7 @@ pub(crate) unsafe fn initialize_libpostal(
     Ok(())
 }
 
-///! Support for initializing `libpostal`'s parser module.
+/// Support for initializing `libpostal`'s parser module.
 pub(crate) unsafe fn initialize_libpostal_parser(
     state: &mut InitializationState,
 ) -> Result<()> {
@@ -58,7 +58,7 @@ pub(crate) unsafe fn initialize_libpostal_parser(
     Ok(())
 }
 
-///! Support for initializing `libpostal`'s parser module.
+/// Support for initializing `libpostal`'s parser module.
 pub(crate) unsafe fn initialize_libpostal_language_classifier(
     state: &mut InitializationState,
 ) -> Result<()> {

--- a/src/addresses.rs
+++ b/src/addresses.rs
@@ -13,7 +13,8 @@ use std::{
 use crate::{geocoders::Geocoder, Result};
 
 /// An address record that we can pass to a geocoder.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Address {
     /// Either the street, or the entire address as a string. This must always
     /// be present.

--- a/src/geocoders/cache/mod.rs
+++ b/src/geocoders/cache/mod.rs
@@ -179,6 +179,7 @@ impl Geocoder for Cache {
         drop(cache_results);
 
         // If we have any cache misses, deal with them.
+        // TODO: Fail on cache missthrough argument
         if !cache_misses.is_empty() {
             // Pass remainder through to our inner geocoder.
             let cache_miss_retries =

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,10 @@ struct Opt {
     #[arg(long = "cache", value_name = "CACHE_URL")]
     cache_url: Option<Url>,
 
+    /// Whether or not cache misses should be geocoded.
+    #[arg(long = "skip-cache-misses")]
+    skip_cache_misses: bool,
+
     /// Include cache keys in the output. Mostly useful for debugging.
     #[arg(long = "cache-output-keys")]
     cache_output_keys: bool,
@@ -252,7 +256,7 @@ async fn main() -> Result<()> {
             <dyn KeyValueStore>::new_from_url(cache_url.to_owned(), cache_key_prefix)
                 .await?;
         geocoder = Box::new(
-            Cache::new(key_value_store, geocoder, opt.cache_output_keys).await?,
+            Cache::new(key_value_store, geocoder, opt.cache_output_keys, opt.skip_cache_misses).await?,
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,8 +128,8 @@ struct Opt {
     cache_url: Option<Url>,
 
     /// Whether or not cache misses should be geocoded.
-    #[arg(long = "skip-cache-misses")]
-    skip_cache_misses: bool,
+    #[arg(long = "cache-hits-only")]
+    cache_hits_only: bool,
 
     /// Include cache keys in the output. Mostly useful for debugging.
     #[arg(long = "cache-output-keys")]
@@ -256,7 +256,13 @@ async fn main() -> Result<()> {
             <dyn KeyValueStore>::new_from_url(cache_url.to_owned(), cache_key_prefix)
                 .await?;
         geocoder = Box::new(
-            Cache::new(key_value_store, geocoder, opt.cache_output_keys, opt.skip_cache_misses).await?,
+            Cache::new(
+                key_value_store,
+                geocoder,
+                opt.cache_output_keys,
+                opt.cache_hits_only,
+            )
+            .await?,
         );
     }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -57,11 +57,11 @@ pub enum OnDuplicateColumns {
 }
 
 /// Data about the CSV file that we include with every chunk to be geocoded.
-struct Shared {
+pub struct Shared {
     /// Which columns contain addresses that we need to geocode?
-    spec: AddressColumnSpec<usize>,
+    pub spec: AddressColumnSpec<usize>,
     /// The header of the output CSV file.
-    out_headers: StringRecord,
+    pub out_headers: StringRecord,
 }
 
 /// We use an atomic counter to keep track of how many chunks currently exist.
@@ -72,11 +72,11 @@ struct Shared {
 static TOTAL_CHUNKS_EXISTING: AtomicI64 = AtomicI64::new(0);
 
 /// A chunk to geocode.
-struct Chunk {
+pub struct Chunk {
     /// Shared information about the CSV file, including headers.
-    shared: Arc<Shared>,
+    pub shared: Arc<Shared>,
     /// The rows to geocode.
-    rows: Vec<StringRecord>,
+    pub rows: Vec<StringRecord>,
 }
 
 impl Chunk {
@@ -411,7 +411,7 @@ async fn geocode_message(
     skip_all,
     fields(rows = chunk.rows.len())
 )]
-async fn geocode_chunk(
+pub async fn geocode_chunk(
     geocoder: &dyn Geocoder,
     mut chunk: Chunk,
     max_retries: u8,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,150 @@
+//! Code to support server mode.
+
+use std::collections::HashMap;
+use std::iter::FromIterator;
+use std::sync::Arc;
+
+use crate::addresses::Address;
+use crate::geocoders::Geocoded;
+use crate::geocoders::Geocoder;
+use anyhow::{format_err, Context, Result};
+use axum::{
+    extract::DefaultBodyLimit,
+    headers::{HeaderMap, HeaderName},
+    http::header::CONTENT_TYPE,
+    http::StatusCode,
+    routing::post,
+    Extension, Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+/// An error message to serialize as JSON on error.
+#[derive(Serialize)]
+struct ErrorResponse {
+    /// A human-readable error.
+    message: String,
+}
+
+impl ErrorResponse {
+    /// Construct an error response from an error.
+    fn new(err: anyhow::Error) -> Self {
+        ErrorResponse {
+            message: err.to_string(),
+        }
+    }
+}
+
+struct State {
+    geocoder: Box<dyn Geocoder>,
+}
+
+// Run the server. Should not return.
+pub async fn run_server(listen_addr: &str, geocoder: Box<dyn Geocoder>) -> Result<()> {
+    // Build our application with a single route.
+    let state = Arc::new(State { geocoder });
+
+    let app = Router::new()
+        .route("/geocode", post(handle_post_geocode))
+        .layer(Extension(state))
+        // Assumes ~128 addresses at ~128 bytes each. More than this would (1)
+        // need to be streamed instead of read into memory, and (2) chunked
+        // before passing to the geocoder layer which expects chunks in the
+        // rough size of `[crate::pipeline::GEOCODE_SIZE]`.
+        .layer(DefaultBodyLimit::max(16384));
+
+    let listen_addr = listen_addr.parse().with_context(|| {
+        format!("could not parse listen address: {:?}", listen_addr)
+    })?;
+
+    // Run it with axum on the given listen address.
+    axum::Server::bind(&listen_addr)
+        .serve(app.into_make_service())
+        .await
+        .context("web server failed to start")
+}
+
+/// Our /geocode request format.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GeocodeRequest {
+    /// Addresses to geocode. These are _always_ a list because the underlying
+    /// engine is much more efficient that way and we to encourage people to
+    /// use it the right way.
+    addresses: Vec<Address>,
+}
+
+/// Our geocode response format.
+#[derive(Debug, Serialize)]
+struct GeocodeResponse {
+    /// The geocoder output. There is one record here for each input record, in
+    /// the same order. `None` means we failed to find a match. `Some` returns
+    /// key/value pairs that are dependent on the configured geocoder.
+    results: Vec<Option<HashMap<String, String>>>,
+}
+
+/// POST /geocode
+async fn handle_post_geocode(
+    Extension(state): Extension<Arc<State>>,
+    headers: HeaderMap,
+    Json(body): Json<GeocodeRequest>,
+) -> Result<(StatusCode, Json<GeocodeResponse>), (StatusCode, Json<ErrorResponse>)> {
+    // Get our geocoder.
+    let geocoder = state.as_ref().geocoder.as_ref();
+
+    // Require users to specify this, so that we can later add JSON support
+    // without breaking anything.
+    if let Err(err) = expect_header_value(&headers, &CONTENT_TYPE, "application/json")
+    {
+        return Err((StatusCode::BAD_REQUEST, Json(ErrorResponse::new(err))));
+    }
+
+    let result = geocoder.geocode_addresses(&body.addresses).await;
+
+    match result {
+        Ok(geocoded) => {
+            let column_names = geocoder.column_names();
+            let response = GeocodeResponse {
+                results: geocoded
+                    .into_iter()
+                    .map(|g: Option<Geocoded>| -> Option<HashMap<String, String>> {
+                        g.map(|g| hash_from_geocoded(column_names, &g))
+                    })
+                    .collect(),
+            };
+            Ok((StatusCode::OK, Json(response)))
+        }
+        Err(err) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(err)),
+        )),
+    }
+}
+
+fn hash_from_geocoded(
+    column_names: &[String],
+    geocoded: &Geocoded,
+) -> HashMap<String, String> {
+    HashMap::from_iter(
+        column_names
+            .iter()
+            .cloned()
+            .zip(geocoded.column_values.iter().cloned()),
+    )
+}
+
+fn expect_header_value(
+    headers: &HeaderMap,
+    header_name: &HeaderName,
+    expected: &str,
+) -> Result<()> {
+    match headers.get(CONTENT_TYPE) {
+        Some(v) if v == expected => Ok(()),
+        Some(v) => Err(format_err!(
+            "expected {} {:?}, got {:?}",
+            header_name,
+            expected,
+            v
+        )),
+        None => Err(format_err!("Missing header {}", header_name)),
+    }
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,0 +1,123 @@
+//! Test server mode.
+
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use cli_test_dir::*;
+use hyper::header::CONTENT_TYPE;
+use reqwest::blocking::{Client, Response};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct AddressJson {
+    street: &'static str,
+    city: Option<&'static str>,
+    state: Option<&'static str>,
+    zipcode: Option<&'static str>,
+}
+#[derive(Serialize)]
+struct AddressesJson {
+    addresses: Vec<AddressJson>,
+}
+
+#[test]
+fn server() -> Result<()> {
+    let testdir = TestDir::new("geocode-csv", "");
+
+    testdir.create_file(
+        "spec.json",
+        r#"{
+    "gc": {
+        "house_number_and_street": [
+            "address_1",
+            "address_2"
+        ],
+        "city": "city",
+        "state": "state",
+        "postcode": "zip_code"
+    }
+}"#,
+    );
+    let mut child = testdir
+        .cmd()
+        .arg("--geocoder=libpostal")
+        .arg("--spec=spec.json")
+        .arg("server")
+        .spawn()
+        .context("server failed to start")?;
+
+    // Call our helper to actually make the HTTP request, clean up our webserver
+    // (always!), and check to see if `result` was an error.
+    let result = server_helper();
+    if let Err(err) = child.kill() {
+        eprintln!("could not stop web server: {}", err);
+    }
+    let response = result?;
+
+    // Receive CSV and check that it contains the correct content.
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = match response.text() {
+            Ok(body) => body,
+            Err(err) => err.to_string(),
+        };
+        panic!("error status from server: {:?}\nbody: {}", status, body);
+    }
+    let output = response.text().context("couldn't get response body")?;
+
+    eprintln!("output from request:\n{}", output);
+    assert!(output.contains("road"));
+    assert!(output.contains("w 34th st"));
+    Ok(())
+}
+
+/// Helper function for `server` test, so that test can clean up the actual
+/// server process. This must _not_ use `assert!` or other functions that panic,
+/// or we won't clean up.
+fn server_helper() -> Result<Response> {
+    // Create an HTTP client.
+    let client = Client::new();
+
+    // Addresses to geocode.
+    let addresses = AddressesJson {
+        addresses: vec![
+            AddressJson {
+                street: "20 W 34th St",
+                city: Some("New York"),
+                state: Some("NY"),
+                zipcode: Some("10118"),
+            },
+            AddressJson {
+                street: "1224 S 760 W",
+                city: Some("Provo"),
+                state: Some("UT"),
+                zipcode: None,
+            },
+        ],
+    };
+
+    // We may need to retry this several times depending on how long the server
+    // takes to start.
+    let connect = || {
+        client
+            .post("http://localhost:8787/geocode")
+            .header(CONTENT_TYPE, "application/json")
+            .json(&addresses)
+            .send()
+            .context("HTTP request failed")
+    };
+
+    // Post a request with JSON content.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match connect() {
+            Ok(res) => break Ok(res),
+            Err(err) if Instant::now() < deadline => {
+                eprintln!("request failed; retrying: {:?}", err);
+                sleep(Duration::from_millis(100));
+            }
+            Err(err) => return Err(err).context("http request timed out with error"),
+        }
+    }
+}


### PR DESCRIPTION
Add a new server mode which allows geocoding of JSON requests, routing first through libpostal address normalization and caching layer before hitting the smarty geocoder. Additionally, add a flag to avoid geocoding of cache misses.