### PR TITLE
"prime" libpostal library when running in server mode

### DIFF
--- a/src/geocoders/libpostal.rs
+++ b/src/geocoders/libpostal.rs
@@ -52,7 +52,7 @@ pub struct LibPostal {
 
 impl LibPostal {
     /// Create a new LibPostal geocoder.
-    pub fn new() -> LibPostal {
+    pub fn new(prime: bool) -> LibPostal {
         describe_counter!(
             "geocodecsv.addresses_parsed.total",
             "Total addresses parsed"
@@ -62,7 +62,11 @@ impl LibPostal {
             .iter()
             .map(|&name| name.to_owned())
             .collect::<Vec<_>>();
-        LibPostal { column_names }
+        let libpostal = LibPostal { column_names };
+        if prime {
+            libpostal.geocode_addresses(&[Address{street: "1 Main St".to_owned(),  city: Some("Anytown".to_owned()), state: Some("VT".to_owned()), zipcode: None}]);
+        }
+        libpostal
     }
 }
 

--- a/src/geocoders/libpostal.rs
+++ b/src/geocoders/libpostal.rs
@@ -52,7 +52,7 @@ pub struct LibPostal {
 
 impl LibPostal {
     /// Create a new LibPostal geocoder.
-    pub fn new(prime: bool) -> LibPostal {
+    pub fn new() -> LibPostal {
         describe_counter!(
             "geocodecsv.addresses_parsed.total",
             "Total addresses parsed"
@@ -62,18 +62,17 @@ impl LibPostal {
             .iter()
             .map(|&name| name.to_owned())
             .collect::<Vec<_>>();
-        let libpostal = LibPostal { column_names };
-        if prime {
-            // The result here isn't useful, we just need to get libpostal to load
-            // its model into memory.
-            let _ = libpostal.geocode_addresses(&[Address {
-                street: "1 Main St".to_owned(),
-                city: Some("Anytown".to_owned()),
-                state: Some("VT".to_owned()),
-                zipcode: None,
-            }]);
-        }
-        libpostal
+        LibPostal { column_names }
+    }
+
+    pub async fn prime() {
+        let libpostal = LibPostal::new();
+        let _ = libpostal.geocode_addresses(&[Address {
+            street: "1 Main St".to_owned(),
+            city: Some("Anytown".to_owned()),
+            state: Some("VT".to_owned()),
+            zipcode: None,
+        }]).await;
     }
 }
 

--- a/src/geocoders/libpostal.rs
+++ b/src/geocoders/libpostal.rs
@@ -64,7 +64,9 @@ impl LibPostal {
             .collect::<Vec<_>>();
         let libpostal = LibPostal { column_names };
         if prime {
-            libpostal.geocode_addresses(&[Address {
+            // The result here isn't useful, we just need to get libpostal to load
+            // its model into memory.
+            let _ = libpostal.geocode_addresses(&[Address {
                 street: "1 Main St".to_owned(),
                 city: Some("Anytown".to_owned()),
                 state: Some("VT".to_owned()),

--- a/src/geocoders/libpostal.rs
+++ b/src/geocoders/libpostal.rs
@@ -69,12 +69,14 @@ impl LibPostal {
         /// "Prime" libpostal by forcing it to load its language model and associated data
         /// into memory with a dummy call.
         let libpostal = LibPostal::new();
-        let _ = libpostal.geocode_addresses(&[Address {
-            street: "1 Main St".to_owned(),
-            city: Some("Anytown".to_owned()),
-            state: Some("VT".to_owned()),
-            zipcode: None,
-        }]).await;
+        let _ = libpostal
+            .geocode_addresses(&[Address {
+                street: "1 Main St".to_owned(),
+                city: Some("Anytown".to_owned()),
+                state: Some("VT".to_owned()),
+                zipcode: None,
+            }])
+            .await;
     }
 }
 

--- a/src/geocoders/libpostal.rs
+++ b/src/geocoders/libpostal.rs
@@ -64,7 +64,12 @@ impl LibPostal {
             .collect::<Vec<_>>();
         let libpostal = LibPostal { column_names };
         if prime {
-            libpostal.geocode_addresses(&[Address{street: "1 Main St".to_owned(),  city: Some("Anytown".to_owned()), state: Some("VT".to_owned()), zipcode: None}]);
+            libpostal.geocode_addresses(&[Address {
+                street: "1 Main St".to_owned(),
+                city: Some("Anytown".to_owned()),
+                state: Some("VT".to_owned()),
+                zipcode: None,
+            }]);
         }
         libpostal
     }

--- a/src/geocoders/libpostal.rs
+++ b/src/geocoders/libpostal.rs
@@ -66,6 +66,8 @@ impl LibPostal {
     }
 
     pub async fn prime() {
+        /// "Prime" libpostal by forcing it to load its language model and associated data
+        /// into memory with a dummy call.
         let libpostal = LibPostal::new();
         let _ = libpostal.geocode_addresses(&[Address {
             street: "1 Main St".to_owned(),

--- a/src/geocoders/libpostal.rs
+++ b/src/geocoders/libpostal.rs
@@ -66,8 +66,8 @@ impl LibPostal {
     }
 
     pub async fn prime() {
-        /// "Prime" libpostal by forcing it to load its language model and associated data
-        /// into memory with a dummy call.
+        // "Prime" libpostal by forcing it to load its language model and associated data
+        // into memory with a dummy call.
         let libpostal = LibPostal::new();
         let _ = libpostal
             .geocode_addresses(&[Address {

--- a/src/geocoders/normalizer.rs
+++ b/src/geocoders/normalizer.rs
@@ -26,13 +26,13 @@ pub struct Normalizer {
 
 impl Normalizer {
     /// Create a new `Normalizer` wrapping the specified geocoder.
-    pub fn new(inner: Box<dyn Geocoder>, prime: bool) -> Normalizer {
+    pub fn new(inner: Box<dyn Geocoder>) -> Normalizer {
         describe_counter!(
             "geocodecsv.addresses_normalized.total",
             "Addresses changed by normalization"
         );
 
-        let libpostal = LibPostal::new(prime);
+        let libpostal = LibPostal::new();
         let mut libpostal_component_indices = HashMap::new();
         for (i, column_name) in libpostal.column_names().iter().enumerate() {
             libpostal_component_indices.insert(column_name.to_owned(), i);

--- a/src/geocoders/normalizer.rs
+++ b/src/geocoders/normalizer.rs
@@ -26,13 +26,13 @@ pub struct Normalizer {
 
 impl Normalizer {
     /// Create a new `Normalizer` wrapping the specified geocoder.
-    pub fn new(inner: Box<dyn Geocoder>) -> Normalizer {
+    pub fn new(inner: Box<dyn Geocoder>, prime: bool) -> Normalizer {
         describe_counter!(
             "geocodecsv.addresses_normalized.total",
             "Addresses changed by normalization"
         );
 
-        let libpostal = LibPostal::new();
+        let libpostal = LibPostal::new(prime);
         let mut libpostal_component_indices = HashMap::new();
         for (i, column_name) in libpostal.column_names().iter().enumerate() {
             libpostal_component_indices.insert(column_name.to_owned(), i);

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,6 +279,10 @@ async fn main() -> Result<()> {
     let result = match opt.cmd {
         // Run in server mode.
         Some(Command::Server { listen_address }) => {
+            // If we're running in server mode, then prime libpostal to load its
+            // model and data into memory. This can take 5-10 seconds,
+            // and we'd prefer that it happens as part of application startup,
+            // rather than at the time of the first request.
             LibPostal::prime().await;
             run_server(&listen_address, geocoder).await
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,7 +252,7 @@ async fn main() -> Result<()> {
             rate_limiter.clone(),
             shared_http_client(CONCURRENCY),
         )?),
-        GeocoderName::LibPostal => Box::new(LibPostal::new(prime.clone())),
+        GeocoderName::LibPostal => Box::new(LibPostal::new(prime)),
     };
 
     // If we were asked, place a cache in front.
@@ -282,7 +282,7 @@ async fn main() -> Result<()> {
 
     // If we were asked, normalize addresses a bit first.
     if opt.normalize {
-        geocoder = Box::new(Normalizer::new(geocoder, prime.clone()));
+        geocoder = Box::new(Normalizer::new(geocoder, prime));
     }
 
     // Decide which command to run.


### PR DESCRIPTION
Libpostal depends on a language model which takes 5-10 seconds to load into memory. Currently, that happens at the time of the first request; this PR instead causes it to happen as part of application startup when it is run in server mode.

```bash
$ export RUST_LOG=debug
$ cargo build && cargo run -- --spec fake_spec.json --geocoder libpostal server
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/geocode-csv --spec fake_spec.json --geocoder libpostal server`
2023-08-09T23:53:24.499782Z  INFO geocode-csv: geocode_csv: new
2023-08-09T23:53:24.499821Z DEBUG geocode-csv: geocode_csv: geocode-csv 1.3.9
2023-08-09T23:53:24.501108Z DEBUG geocode-csv:libpostal_setup_datadir: libpostal_rust::init: new
2023-08-09T23:53:24.501136Z DEBUG geocode-csv:libpostal_setup_datadir: libpostal_rust::probe: probing for libpostal data directory
2023-08-09T23:53:24.501159Z DEBUG geocode-csv:libpostal_setup_datadir: libpostal_rust::probe: using /usr/local/share/libpostal as libpostal data directory
2023-08-09T23:53:24.567769Z DEBUG geocode-csv:libpostal_setup_datadir: libpostal_rust::init: close time.busy=66.6ms time.idle=30.8µs
2023-08-09T23:53:24.567855Z DEBUG geocode-csv:libpostal_setup_parser_datadir: libpostal_rust::init: new
2023-08-09T23:53:28.198433Z DEBUG geocode-csv:libpostal_setup_parser_datadir: libpostal_rust::init: close time.busy=3.63s time.idle=26.3µs
```